### PR TITLE
Implement save as new filter flow

### DIFF
--- a/src/app/features/filter-panel/filter-panel.component.html
+++ b/src/app/features/filter-panel/filter-panel.component.html
@@ -27,7 +27,7 @@
             @if (filterNameInput.errors?.['pattern']) {
             <p class="text-red-600 text-sm mt-1">Please avoid using ', %, <,>, ", &, (, ).</p>
             }
-            @if(false){
+            @if(showSaveAsNewFilterOption()){
               <div class="flex items-center mb-2">
                 <input 
                   type="checkbox" 

--- a/src/app/features/filter-panel/filter-panel.component.ts
+++ b/src/app/features/filter-panel/filter-panel.component.ts
@@ -107,6 +107,18 @@ export class FilterPanelComponent implements OnInit, OnChanges {
 
   private _isSaveFilterPopoverVisible = signal<boolean>(false);
   private _saveAsNewFilter = signal<boolean>(false);
+  private selectedSavedFilterId = computed(() => {
+    const dashboard = this.filtersFromDashboard();
+    if (
+      dashboard &&
+      dashboard.filters?.category &&
+      dashboard.filters.category.type === 'saved'
+    ) {
+      return dashboard.filters.category.category.id;
+    }
+    return null;
+  });
+  showSaveAsNewFilterOption = computed(() => this.selectedSavedFilterId() !== null);
   suggestionsWithCounts = signal<SearchCountObject | null>(null);
   private activeFilterTypeSignal = signal<string>('category');
   private activeFilterSection = signal<string>('quickFilters');
@@ -1081,7 +1093,12 @@ export class FilterPanelComponent implements OnInit, OnChanges {
     }
 
     this.filterDataService
-      .saveFilter(this.currentFilterData, filterName, this._saveAsNewFilter())
+      .saveFilter(
+        this.currentFilterData,
+        filterName,
+        this._saveAsNewFilter(),
+        this.selectedSavedFilterId()
+      )
       .subscribe({
         next: (response) => {
           this.closeSaveFilterPopover();

--- a/src/app/features/filter-panel/services/filter-data.service.ts
+++ b/src/app/features/filter-panel/services/filter-data.service.ts
@@ -342,13 +342,28 @@ export class FilterDataService {
       return url.toString();
     }
 
-  saveFilter(filterData: FilterForm, criteriaName: string, isNewFilter: boolean = true): Observable<any> {
+  saveFilter(
+    filterData: FilterForm,
+    criteriaName: string,
+    isNewFilter: boolean = true,
+    criteriaId?: number | null
+  ): Observable<any> {
     const url = environment.apiUrl + "/CvBankInsights/CvBankSavedFilter";
-    const payload = this.buildSaveFilterPayload(filterData, criteriaName, isNewFilter);
+    const payload = this.buildSaveFilterPayload(
+      filterData,
+      criteriaName,
+      isNewFilter,
+      criteriaId ?? undefined
+    );
     return this.http.post(url, payload);
   }
 
-  private buildSaveFilterPayload(filterData: FilterForm, criteriaName: string, isNewFilter: boolean): SaveFilterRequest {
+  private buildSaveFilterPayload(
+    filterData: FilterForm,
+    criteriaName: string,
+    isNewFilter: boolean,
+    criteriaId?: number
+  ): SaveFilterRequest {
     const parameters: Record<string, string> = {};
 
     if (filterData.keyword) {
@@ -468,13 +483,19 @@ export class FilterDataService {
     }
     const totalCvCount = this.getTotalCvCount();
 
-    return {
-      isInsert: 1, 
+    const payload: SaveFilterRequest = {
+      isInsert: isNewFilter ? 1 : 2,
       cpId: this.getUserCompanyId(),
       criteriaName: criteriaName,
       parameters: parameters,
-      cvCount: this.getTotalCvCount()
+      cvCount: totalCvCount,
     };
+
+    if (!isNewFilter && criteriaId !== undefined) {
+      payload.criteriaId = criteriaId;
+    }
+
+    return payload;
   }
 
   private getUserCompanyId(): string {


### PR DESCRIPTION
## Summary
- expose saved filter selection in FilterPanel
- show *Save as New Filter* option when editing a saved filter
- include criteriaId and set `isInsert` correctly when updating a saved filter

## Testing
- `npm test` *(fails: Cannot find module errors)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888bdf0aa3c8329b8afe39c6aec77b4