### PR TITLE
Implement saved filter update option

### DIFF
--- a/src/app/features/filter-panel/filter-panel.component.html
+++ b/src/app/features/filter-panel/filter-panel.component.html
@@ -27,7 +27,7 @@
             @if (filterNameInput.errors?.['pattern']) {
             <p class="text-red-600 text-sm mt-1">Please avoid using ', %, <,>, ", &, (, ).</p>
             }
-            @if(false){
+            @if(isFilterFromSavedFilter()){
               <div class="flex items-center mb-2">
                 <input 
                   type="checkbox" 

--- a/src/app/features/filter-panel/filter-panel.component.ts
+++ b/src/app/features/filter-panel/filter-panel.component.ts
@@ -107,6 +107,7 @@ export class FilterPanelComponent implements OnInit, OnChanges {
 
   private _isSaveFilterPopoverVisible = signal<boolean>(false);
   private _saveAsNewFilter = signal<boolean>(false);
+  private selectedSavedFilterId = signal<string | null>(null);
   suggestionsWithCounts = signal<SearchCountObject | null>(null);
   private activeFilterTypeSignal = signal<string>('category');
   private activeFilterSection = signal<string>('quickFilters');
@@ -214,6 +215,8 @@ export class FilterPanelComponent implements OnInit, OnChanges {
   isSaveFilterPopoverVisible = computed(() =>
     this._isSaveFilterPopoverVisible()
   );
+
+  isFilterFromSavedFilter = computed(() => this.selectedSavedFilterId() !== null);
 
   saveAsNewFilter = computed(() => this._saveAsNewFilter());
 
@@ -848,6 +851,7 @@ export class FilterPanelComponent implements OnInit, OnChanges {
   async syncFilterFormWithDashboardFilters() {
     if (this.filtersFromDashboard()) {
       const filter = this.filtersFromDashboard();
+      this.selectedSavedFilterId.set(null);
       if (
         filter?.filters.age &&
         this.isDefaultRange(filter?.filters.age, DefaultAge)
@@ -956,6 +960,9 @@ export class FilterPanelComponent implements OnInit, OnChanges {
         filter?.filters.category &&
         filter.filters.category.type === 'saved'
       ) {
+        this.selectedSavedFilterId.set(
+          filter.filters.category.category.filters?.['id'] ?? null
+        );
         const form = await QueryBuilderReverse.toFilterForm(
           filter.filters.category.category.filters,
           this.filterDataService
@@ -1081,7 +1088,12 @@ export class FilterPanelComponent implements OnInit, OnChanges {
     }
 
     this.filterDataService
-      .saveFilter(this.currentFilterData, filterName, this._saveAsNewFilter())
+      .saveFilter(
+        this.currentFilterData,
+        filterName,
+        this._saveAsNewFilter(),
+        this.selectedSavedFilterId()
+      )
       .subscribe({
         next: (response) => {
           this.closeSaveFilterPopover();

--- a/src/app/features/filter-panel/models/filter-datamodel.ts
+++ b/src/app/features/filter-panel/models/filter-datamodel.ts
@@ -179,7 +179,6 @@ export interface SaveFilterRequest {
   isInsert: number;
   id?: string;
   cpId: string;
-  criteriaId?: number;
   criteriaName: string;
   parameters: Record<string, string>;
   cvCount: number;

--- a/src/app/features/filter-panel/services/filter-data.service.ts
+++ b/src/app/features/filter-panel/services/filter-data.service.ts
@@ -342,13 +342,28 @@ export class FilterDataService {
       return url.toString();
     }
 
-  saveFilter(filterData: FilterForm, criteriaName: string, isNewFilter: boolean = true): Observable<any> {
+  saveFilter(
+    filterData: FilterForm,
+    criteriaName: string,
+    isNewFilter: boolean = true,
+    id: string | null = null
+  ): Observable<any> {
     const url = environment.apiUrl + "/CvBankInsights/CvBankSavedFilter";
-    const payload = this.buildSaveFilterPayload(filterData, criteriaName, isNewFilter);
+    const payload = this.buildSaveFilterPayload(
+      filterData,
+      criteriaName,
+      isNewFilter,
+      id
+    );
     return this.http.post(url, payload);
   }
 
-  private buildSaveFilterPayload(filterData: FilterForm, criteriaName: string, isNewFilter: boolean): SaveFilterRequest {
+  private buildSaveFilterPayload(
+    filterData: FilterForm,
+    criteriaName: string,
+    isNewFilter: boolean,
+    id: string | null
+  ): SaveFilterRequest {
     const parameters: Record<string, string> = {};
 
     if (filterData.keyword) {
@@ -468,13 +483,19 @@ export class FilterDataService {
     }
     const totalCvCount = this.getTotalCvCount();
 
-    return {
-      isInsert: 1, 
+    const payload: SaveFilterRequest = {
+      isInsert: id && !isNewFilter ? 2 : 1,
       cpId: this.getUserCompanyId(),
       criteriaName: criteriaName,
       parameters: parameters,
-      cvCount: this.getTotalCvCount()
+      cvCount: totalCvCount
     };
+
+    if (id && !isNewFilter) {
+      payload.id = id;
+    }
+
+    return payload;
   }
 
   private getUserCompanyId(): string {

--- a/src/app/features/saved-search/saved-filters-tab/saved-filters-tab.component.ts
+++ b/src/app/features/saved-search/saved-filters-tab/saved-filters-tab.component.ts
@@ -73,7 +73,7 @@ export class SavedFiltersTabComponent implements OnInit {
             id: $event.filterId as number,
             value: $event.groupId as number,
             categoryName: $event.title,
-            filters: $event.filters,
+            filters: { ...$event.filters, id: $event.id },
           },
         },
       });


### PR DESCRIPTION
## Summary
- allow passing saved filter id when opening from saved filters tab
- show **Save as New Filter** checkbox when a saved filter is loaded
- handle saving existing filters in `FilterPanelComponent`
- support `id` and `isInsert` modes in `FilterDataService`
- adapt data model for saved filter id

## Testing
- `npx ng lint` *(fails: 523 problems)*
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888c1fc0e9c8329a61dd09e0b43765b