### PR TITLE
Handle saved filter updates

### DIFF
--- a/src/app/features/filter-panel/models/filter-datamodel.ts
+++ b/src/app/features/filter-panel/models/filter-datamodel.ts
@@ -179,7 +179,6 @@ export interface SaveFilterRequest {
   isInsert: number;
   id?: string;
   cpId: string;
-  criteriaId?: string;
   criteriaName: string;
   parameters: Record<string, string>;
   cvCount: number;

--- a/src/app/features/filter-panel/services/filter-data.service.ts
+++ b/src/app/features/filter-panel/services/filter-data.service.ts
@@ -346,14 +346,14 @@ export class FilterDataService {
     filterData: FilterForm,
     criteriaName: string,
     isNewFilter: boolean = true,
-    criteriaId: string | null = null
+    id: string | null = null
   ): Observable<any> {
     const url = environment.apiUrl + "/CvBankInsights/CvBankSavedFilter";
     const payload = this.buildSaveFilterPayload(
       filterData,
       criteriaName,
       isNewFilter,
-      criteriaId
+      id
     );
     return this.http.post(url, payload);
   }
@@ -362,7 +362,7 @@ export class FilterDataService {
     filterData: FilterForm,
     criteriaName: string,
     isNewFilter: boolean,
-    criteriaId: string | null
+    id: string | null
   ): SaveFilterRequest {
     const parameters: Record<string, string> = {};
 
@@ -484,15 +484,15 @@ export class FilterDataService {
     const totalCvCount = this.getTotalCvCount();
 
     const payload: SaveFilterRequest = {
-      isInsert: criteriaId && !isNewFilter ? 2 : 1,
+      isInsert: id && !isNewFilter ? 2 : 1,
       cpId: this.getUserCompanyId(),
       criteriaName: criteriaName,
       parameters: parameters,
       cvCount: totalCvCount
     };
 
-    if (criteriaId && !isNewFilter) {
-      payload.criteriaId = criteriaId;
+    if (id && !isNewFilter) {
+      payload.id = id;
     }
 
     return payload;


### PR DESCRIPTION
## Summary
- allow updating existing saved filters by sending `id` in payload
- use the `id` field when saving an existing saved filter

## Testing
- `npm run lint` *(fails: Lint errors found)*
- `npm test` *(fails: several modules could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6888cc6588148329b32cfce8f49459a3